### PR TITLE
App Name in Uppercase and change of message when app is not connected to internet.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">MovieHunt</string>
+    <string name="app_name">MOVIEHUNT</string>
     <string name="placeholder">--</string>
     <string name="vote_count" formatted="false">%s reviews</string>
     <string name="category_now_playing">Now Playing</string>
@@ -8,5 +8,5 @@
     <string name="category_upcoming">Upcoming</string>
     <string name="view_all">View All</string>
 
-    <string name="error_network_fail">Looks like your are offline!</string>
+    <string name="error_network_fail">Opps!!! You are not connected to internet</string>
 </resources>


### PR DESCRIPTION
Giving **Upper case** to the app name **attract** more number of users, it even look more **attractive**.
The **internet connection** error message has now changed to " Opps!!! You are not connected to internet "  